### PR TITLE
constrain regex matching in reference replacement

### DIFF
--- a/src/fixtures-loader.coffee
+++ b/src/fixtures-loader.coffee
@@ -57,7 +57,7 @@ module.exports =
       _.each object, (value, key) =>
         if _.values(value)?[0] == '@'
           identifier = value.substring 1
-          referencedObject = @getRandomMatchingObject identifier
+          referencedObject = @getRandomMatchingObject "^"+identifier+"$"
 
           if referencedObject?[idKey]
             object[key] = referencedObject[idKey]
@@ -143,4 +143,5 @@ module.exports =
           models[modelData.name].create object
         .then (savedObject) =>
           @savedData[fixture.identifier] = savedObject
-          console.log "[#{modelData.name}] - #{fixture.identifier} imported (id : #{savedObject?[idKey]})"
+          console.log "[#{modelData.name}] - #{fixture.identifier} " +
+                      "imported (id : #{savedObject?[idKey]})"

--- a/src/load-fixtures.coffee
+++ b/src/load-fixtures.coffee
@@ -1,5 +1,5 @@
-#!/usr/bin/env node
-
+`#!/usr/bin/env node
+`
 require 'coffee-script/register'
 optimist = require 'optimist'
 app = require '../../../server/server'

--- a/src/load-fixtures.coffee
+++ b/src/load-fixtures.coffee
@@ -1,5 +1,5 @@
-`#!/usr/bin/env node
-`
+#!/usr/bin/env node
+
 require 'coffee-script/register'
 optimist = require 'optimist'
 app = require '../../../server/server'

--- a/test/index.test.coffee
+++ b/test/index.test.coffee
@@ -70,7 +70,7 @@ describe 'loopback-fixtures', ->
       it 'with existing reference', (done) ->
         fixtureLoader.replaceReferenceInObjects fixtureLoader.savedData.user
         .then ->
-          expect(fixtureLoader.getRandomMatchingObject).to.have.been.calledWith 'group_yellow'
+          expect(fixtureLoader.getRandomMatchingObject).to.have.been.calledWith '^group_yellow$'
           done()
 
       it 'and remplace reference key', (done) ->


### PR DESCRIPTION
This fixes #11 by limiting the matches to the regex when looking up responses.

I wasn't sure the best way to construct a test for this due to randomness in the matching, but I did verify this didn't break any existing tests. @sghribi lmk if you have thoughts there.

Cheers, thanks for the lib, btw! 